### PR TITLE
Fix emoji regex pattern in clean_title function

### DIFF
--- a/functions/misc_functions.py
+++ b/functions/misc_functions.py
@@ -114,7 +114,7 @@ def clean_title(title):
                                              u"\U0001F600-\U0001F64F"
                                              u"\U0001F300-\U0001F5FF"
                                              u"\U0001F680-\U0001F6FF"
-                                             u"\U0001F1E0-\U0001F1FF"
+                                             u"\U0001F1E6-\U0001F1FF"
                                              "]+", flags=re.UNICODE)
     temp = re.sub(emoji_regex_pattern, "", temp)
     return temp


### PR DESCRIPTION
Correct the regex pattern to accurately match regional indicator symbols in the clean_title function.